### PR TITLE
Allow emulated startup of launcher and installer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	branch = master
 [submodule "micropython"]
 	path = micropython
-	url = https://github.com/SHA2017-badge/micropython-esp32.git
+	url = https://github.com/HackerHotel/micropython-esp32.git
 	branch = master
 [submodule "ugfx"]
 	path = ugfx

--- a/README.md
+++ b/README.md
@@ -107,6 +107,5 @@ Badge Emulator
 --------------
 ```
 make -C micropython/unix
-cd micropython/unix
-./micropython ../../examples/Game\ of\ Life/game_of_life.py
+./emulator/emulate.py examples/Game\ of\ Life/game_of_life.py
 ```

--- a/emulator/badge.py
+++ b/emulator/badge.py
@@ -1,0 +1,14 @@
+# Emulating the badge module
+#
+# The badge module is a C module with Python bindings
+# on the real badge, but for the emulator it's just a
+# plain python module.
+
+def nvs_get_u16(namespace, key, value):
+    return value
+
+def eink_init():
+    "ok"
+
+def safe_mode():
+    return False

--- a/emulator/emulate.py
+++ b/emulator/emulate.py
@@ -1,0 +1,23 @@
+#!./micropython/unix/micropython
+
+# 'Emulator' to run badge micropython scripts on linux.
+#
+# Usage: './emulator/emulate.py micropython/esp32/modules/launcher.py'
+#
+# Needs this wrapper python script so the python module loader prefers the
+# emulated module implementations in './emulator' over the 'real'
+# implementations next to the to-be-emulated application.
+
+import sys,os
+
+print('Running',sys.argv[1],'in badge emulator')
+
+dir = '/'.join(sys.argv[1].split('/')[:-1])
+file = sys.argv[1].split('/')[-1]
+
+sys.path.append(dir)
+
+print('looking for',file,'in sys.path:',sys.path)
+
+__import__(file)
+print('yolo')

--- a/emulator/esp.py
+++ b/emulator/esp.py
@@ -1,0 +1,1 @@
+# Emulating the ESP API:

--- a/emulator/machine.py
+++ b/emulator/machine.py
@@ -1,0 +1,14 @@
+# Emulating the machine API
+
+class Pin:
+    """"tee hee"""
+
+class RTC:
+    def wake_on_ext0(self, pin, level):
+      "ok"
+
+class Timer:
+    PERIODIC=1
+
+    def init(self, mode, period, callback):
+        "TODO"


### PR DESCRIPTION
Restructured some bits to make it easier to fill in the blanks. With these
changes the emulator can successfully start the launcher and the installer,
though actually interacting with them is not yet supported.

Additional benefit is that this allows moving some of the emulation code out
of the micropython repo, keeping that repo more in sync with upstream.

Merge https://github.com/HackerHotel/micropython-esp32/pull/1 and update the
submodule in this PR before merging this PR.